### PR TITLE
Improve package discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 /native-test
 /native-test.build_artifacts.txt
 /test.build_artifacts.txt
+.clj-kondo/.cache
+.lsp
+!.lsp/config.edn
+.nrepl-port

--- a/src/clj_easy/graal_build_time.clj
+++ b/src/clj_easy/graal_build_time.clj
@@ -7,9 +7,12 @@
              ^{:static true} [packageListStr ["[Ljava.lang.String;"] String]]))
 
 (defn jar-file-entry->package [nm]
-  (->> (str/split nm (re-pattern (System/getProperty "file.separator")))
-       drop-last
-       (str/join ".")))
+  (let [package (->> (str/split nm (re-pattern (System/getProperty "file.separator")))
+                     drop-last
+                     (str/join "."))]
+    (when (str/blank? package)
+      (println "WARN: Single segment package found for class:" nm ".This class has no package and it will not be added to the result packages."))
+    package))
 
 (defn ^:private consider-jar-file-entry? [nm]
   (and (not (str/starts-with? nm (str "clojure" (System/getProperty "file.separator"))))


### PR DESCRIPTION
This should improve the packages output as:

- first filter all valid packages using replace instead of regex
- remove children parents if parent ones were already added

Example output used on clojure-lsp:
```
Registering packages for build time initialization: clojure, cognitect, borkdude, next, sci, camel_snake_kebab, cljfmt, io.aviso, cheshire, anonimitoraf, clj_kondo, datalog, edamame, taoensso, clj_easy, clojure_lsp, medley, rewrite_clj
```