### PR TITLE
Check for parent package now considers dot separator

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -73,12 +73,13 @@
   (b/compile-clj {:basis uber-basis
                   :src-dirs ["test"]
                   :class-dir class-dir
-                  :ns-compile '[clj-easy.graal-build-time.main]})
+                  :ns-compile '[graal-build-time-test-app.main
+                                graal-build-time-test.core]})
   (println "Building uberjar.")
   (b/uber {:class-dir class-dir
            :uber-file "target/test.jar"
            :basis uber-basis
-           :main 'clj-easy.graal-build-time.main}))
+           :main 'graal-build-time-test-app.main}))
 
 (defn deploy [opts]
   (println "All set for deployment 🚀🚀")

--- a/src/clj_easy/graal_build_time.clj
+++ b/src/clj_easy/graal_build_time.clj
@@ -22,7 +22,7 @@
 
 (defn ^:private contains-parent? [packages package]
   (some #(and (not= % package)
-              (str/starts-with? package %))
+              (str/starts-with? (str package ".")  (str % ".")))
         packages))
 
 (defn unique-packages [packages]

--- a/src/clj_easy/graal_build_time.clj
+++ b/src/clj_easy/graal_build_time.clj
@@ -43,8 +43,6 @@
       unique)))
 
 (defn packages-from-dir [^Path dir]
-  ;; TODO: this needs unit tests as it's not exercises in integration test
-  (println "-packages-from-dir" dir)
   (let [f (.toFile dir)
         files (rest (file-seq f))
         relatives (map (fn [^java.io.File f]

--- a/src/clj_easy/graal_build_time.clj
+++ b/src/clj_easy/graal_build_time.clj
@@ -13,7 +13,7 @@
                      drop-last
                      (str/join "."))]
     (when (str/blank? package)
-      (println "WARN: Single segment package found for class:" nm ".This class has no package and it will not be added to the result packages."))
+      (println (str "WARN: Single segment package found for class: " nm ". This class has no package and it will not be added to the result packages.")))
     package))
 
 (defn ^:private consider-entry? [nm file-sep]

--- a/test/clj_easy/graal_build_time_test.clj
+++ b/test/clj_easy/graal_build_time_test.clj
@@ -7,12 +7,19 @@
 (deftest package-list-test
   (-> (p/process ["bb" "uber"] {:inherit true})
       (p/check))
-  (let [expected "clojure, graal_build_time_test, graal_build_time_test_app, clj_easy"]
+  (let [expected-packages "clojure, graal_build_time_test, graal_build_time_test_app, clj_easy"
+        expected-warning #"WARN: Single segment .* single_segment_example__init.class"]
     (testing "packages from directory"
-      (is (= expected
-             (-> (bt/-packageList [(.toPath (io/file "target/classes"))])
-                 (bt/-packageListStr)))))
+      (is (re-find
+            expected-warning
+            (with-out-str
+              (is (= expected-packages
+                     (-> (bt/-packageList [(.toPath (io/file "target/classes"))])
+                         (bt/-packageListStr))))))))
     (testing "packages from jar"
-      (is (= expected
-             (-> (bt/-packageList [(.toPath (io/file "target/test.jar"))])
-                 (bt/-packageListStr)))))))
+      (is (re-find
+            expected-warning
+            (with-out-str
+              (is (= expected-packages
+                     (-> (bt/-packageList [(.toPath (io/file "target/test.jar"))])
+                         (bt/-packageListStr))))))))))

--- a/test/clj_easy/graal_build_time_test.clj
+++ b/test/clj_easy/graal_build_time_test.clj
@@ -7,11 +7,12 @@
 (deftest package-list-test
   (-> (p/process ["bb" "uber"] {:inherit true})
       (p/check))
-  (testing "packages from directory"
-    (is (= "clojure, clj_easy"
-           (-> (bt/-packageList [(.toPath (io/file "target/classes"))])
-               (bt/-packageListStr)))))
-  (testing "packages from jar"
-    (is (= "clojure, clj_easy"
-           (-> (bt/-packageList [(.toPath (io/file "target/test.jar"))])
-               (bt/-packageListStr))))))
+  (let [expected "clojure, graal_build_time_test, graal_build_time_test_app, clj_easy"]
+    (testing "packages from directory"
+      (is (= expected
+             (-> (bt/-packageList [(.toPath (io/file "target/classes"))])
+                 (bt/-packageListStr)))))
+    (testing "packages from jar"
+      (is (= expected
+             (-> (bt/-packageList [(.toPath (io/file "target/test.jar"))])
+                 (bt/-packageListStr)))))))

--- a/test/graal_build_time_test/core.clj
+++ b/test/graal_build_time_test/core.clj
@@ -1,0 +1,7 @@
+(ns graal-build-time-test.core
+  "This package will be included in build init registration.
+  It is included to test that:
+   graal_build_time_test_app is not excluded because it happens to start with this package's name:
+   graal_build_time_test")
+
+(defn dummy [])

--- a/test/graal_build_time_test_app/main.clj
+++ b/test/graal_build_time_test_app/main.clj
@@ -1,6 +1,5 @@
-(ns clj-easy.graal-build-time.main
+(ns graal-build-time-test-app.main
   (:gen-class))
 
 (defn -main []
   (println "Hello world"))
-

--- a/test/graal_build_time_test_app/main.clj
+++ b/test/graal_build_time_test_app/main.clj
@@ -1,4 +1,5 @@
 (ns graal-build-time-test-app.main
+  (:require [single-segment-example])
   (:gen-class))
 
 (defn -main []

--- a/test/single_segment_example.clj
+++ b/test/single_segment_example.clj
@@ -1,0 +1,8 @@
+(ns single-segment-example
+  "Single segment namespaces generate no resulting package.
+  As such, they can't be included for build time registration.
+
+  This namespace is referenced by our graal build time test app,
+  it should generate a warning and be properly skipped.")
+
+(defn dummy [])


### PR DESCRIPTION
This fixes, for example, erroneously excluding package sci_test
when package sci is present.

+ beefed up tests a bit.