### PR TITLE
maint: turf old tools.build concurrency hack

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -1,6 +1,3 @@
-;; see https://ask.clojure.org/index.php/10905/control-transient-deps-that-compiled-assembled-into-uberjar?show=10913#c10913
-(require 'clojure.tools.deps.alpha.util.s3-transporter)
-
 (ns build
   (:refer-clojure :exclude [compile])
   (:require

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
  {:svm
   ;; this library is "provided"
   {:extra-deps {org.graalvm.nativeimage/svm {:mvn/version "21.3.0"}}}
-  :build {:deps {io.github.clojure/tools.build {:git/tag "v0.6.3" :git/sha "4a1b53a"}
+  :build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}
                  babashka/fs {:mvn/version "0.1.0"}
                  babashka/process {:mvn/version "0.0.2"}
                  io.github.slipset/deps-deploy {:sha "9b8db1f57722d19cf92de57ac7db28d71a915bcf"}}

--- a/test-hello-world/build.clj
+++ b/test-hello-world/build.clj
@@ -1,10 +1,6 @@
-;; see https://ask.clojure.org/index.php/10905/control-transient-deps-that-compiled-assembled-into-uberjar?show=10913#c10913
-(require 'clojure.tools.deps.alpha.util.s3-transporter)
-
 (ns build
   (:refer-clojure :exclude [compile])
-  (:require [babashka.fs :as fs]
-            [clojure.tools.build.api :as b]))
+  (:require [clojure.tools.build.api :as b]))
 
 (def lib 'hello-world/hello-world)
 (def class-dir "target/classes")

--- a/test-hello-world/deps.edn
+++ b/test-hello-world/deps.edn
@@ -2,6 +2,6 @@
  :deps {lib1/lib1 {:local/root "lib1/target/lib1.jar"}
         lib2/lib2 {:local/root "lib2/target/lib2.jar"}
         clj-easy/graal-build-time {:local/root "target/graal-build-time.jar"}}
- :aliases {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.6.3" :git/sha "4a1b53a"}
+ :aliases {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}
                           babashka/fs {:mvn/version "0.1.0"}}
                    :ns-default build}}}

--- a/test-hello-world/lib1/build.clj
+++ b/test-hello-world/lib1/build.clj
@@ -1,6 +1,3 @@
-;; see https://ask.clojure.org/index.php/10905/control-transient-deps-that-compiled-assembled-into-uberjar?show=10913#c10913
-(require 'clojure.tools.deps.alpha.util.s3-transporter)
-
 (ns build
   (:refer-clojure :exclude [compile])
   (:require [clojure.tools.build.api :as b]))

--- a/test-hello-world/lib1/deps.edn
+++ b/test-hello-world/lib1/deps.edn
@@ -1,3 +1,3 @@
 {:paths ["src"]
- :aliases {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.6.3" :git/sha "4a1b53a"}}
+ :aliases {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}}
                    :ns-default build}}}

--- a/test-hello-world/lib2/build.clj
+++ b/test-hello-world/lib2/build.clj
@@ -1,6 +1,3 @@
-;; see https://ask.clojure.org/index.php/10905/control-transient-deps-that-compiled-assembled-into-uberjar?show=10913#c10913
-(require 'clojure.tools.deps.alpha.util.s3-transporter)
-
 (ns build
   (:refer-clojure :exclude [compile])
   (:require [clojure.tools.build.api :as b]))

--- a/test-hello-world/lib2/deps.edn
+++ b/test-hello-world/lib2/deps.edn
@@ -1,3 +1,3 @@
 {:paths ["src"]
- :aliases {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.6.3" :git/sha "4a1b53a"}}
+ :aliases {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}}
                    :ns-default build}}}


### PR DESCRIPTION
It has apparently been fixed:
https://ask.clojure.org/index.php/10905/control-transient-deps-that-compiled-assembled-into-uberjar?show=11481#c11481