### PR TITLE
maint: bump build and test deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,30 +14,33 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup GraalVM
-        uses: DeLaGuardo/setup-graalvm@5.0
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm: "21.3.0"
-          java: java11
+          java-version: '17.0.8'
+          distribution: 'graalvm-community'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Babashka
-        uses: turtlequeue/setup-babashka@v1.3.0
+        uses: DeLaGuardo/setup-clojure@11.0
         with:
-          babashka-version: 0.6.4
+          bb: 'latest'
+
+      - name: Tools versions
+        run: |
+          java --version
+          bb --version
 
       - name: Apply Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2/repository
             ~/.gitlibs
           key: ${{ runner.os }}-graal-build-time-${{ hashFiles('**/deps.edn') }}
           restore-keys: "$graal-build-time-"
-
-      - name: Setup build tools
-        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Run tests
         run: bb test
@@ -52,15 +55,27 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Babashka
-        uses: turtlequeue/setup-babashka@v1.3.0
+        uses: DeLaGuardo/setup-clojure@11.0
         with:
-          babashka-version: 0.6.4
+          bb: 'latest'
+
+      # any JDK will do to compile sources, but let's choose one
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Tools versions
+        run: |
+          java --version
+          bb --version
 
       - name: Apply Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2/repository

--- a/bb.edn
+++ b/bb.edn
@@ -1,4 +1,5 @@
-{:paths ["."]
+{:min-bb-version "1.3.182"
+ :paths ["."]
  :tasks
  {:requires ([babashka.fs :as fs]
              [babashka.tasks :as tasks]

--- a/deps.edn
+++ b/deps.edn
@@ -3,15 +3,15 @@
  :aliases
  {:svm
   ;; this library is "provided"
-  {:extra-deps {org.graalvm.nativeimage/svm {:mvn/version "21.3.0"}}}
+  {:extra-deps {org.graalvm.nativeimage/svm {:mvn/version "23.0.1"}}}
   :build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}
-                 babashka/fs {:mvn/version "0.1.0"}
-                 babashka/process {:mvn/version "0.0.2"}
-                 io.github.slipset/deps-deploy {:sha "9b8db1f57722d19cf92de57ac7db28d71a915bcf"}}
+                 babashka/fs {:mvn/version "0.4.19"}
+                 babashka/process {:mvn/version "0.5.21"}
+                 slipset/deps-deploy {:mvn/version "0.2.1"}}
           :ns-default build}
   :uber {:extra-paths ["test"]}
   :test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner
-                      {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
-                      babashka/process {:mvn/version "0.0.2"}}
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                      babashka/process {:mvn/version "0.5.21"}}
          :exec-fn cognitect.test-runner.api/test}}}

--- a/test-hello-world/bb.edn
+++ b/test-hello-world/bb.edn
@@ -67,20 +67,16 @@
              (assert env "Set GRAALVM_HOME")
              env)}
 
-  -graalvm-native-image
-  {:doc "Installs/resolves graalvm native-image binary"
-   :depends [graalvm]
-   :task (do (shell (str (fs/file graalvm
-                                  "bin"
-                                  (if windows?
-                                    "gu.cmd"
-                                    "gu")))
-                    "install" "native-image")
-             (str (fs/file graalvm
-                           "bin"
-                           (if windows?
-                             "native-image.cmd"
-                             "native-image"))))}
+  -graalvm-native-image-exe
+  {:doc "Resolves and returns graalvm native-image binary"
+   :task (when-let [native-image (if-let [ghome (System/getenv "GRAALVM_HOME")]
+                                   (or (fs/which (fs/file ghome "bin" "native-image"))
+                                       (throw (ex-info "Could not find GraalVM native-image via GRAALVM_HOME." {})))
+                                   (or (fs/which "native-image")
+                                       (throw (ex-info "GRAALVM_HOME not set, and did not find GraalVM native-image on PATH" {}))))]
+           (println "Using GraalVM native-image:" (str native-image))
+           (shell native-image "--version")
+           native-image)}
 
   ;;
   ;; native image from uber
@@ -95,13 +91,13 @@
   native-image-uber
   {:doc     "Builds native image from uber"
    :depends [build
-             -graalvm-native-image
+             -graalvm-native-image-exe
              -native-image-uber-fname
              -native-image-uber-name]
    :task (if (seq (fs/modified-since -native-image-uber-fname ["target/hello-world.jar"]))
            (do
              (println "Building" -native-image-uber-fname)
-             (shell -graalvm-native-image
+             (shell -graalvm-native-image-exe
                     ;; note: we are omitting --initialize-at-build-time
                     "-jar" "target/hello-world.jar"
                     "--no-fallback"
@@ -128,7 +124,7 @@
   native-image-classes
   {:doc     "Builds native image from classes"
    :depends [build
-             -graalvm-native-image
+             -graalvm-native-image-exe
              -native-image-classes-fname
              -native-image-classes-name]
    :task
@@ -136,7 +132,7 @@
      (if (seq (fs/modified-since -native-image-classes-fname "target/classes"))
        (do
          (println "Building" -native-image-classes-fname)
-         (shell -graalvm-native-image
+         (shell -graalvm-native-image-exe
                 ;; note: we are omitting --initialize-at-build-time
                 "-cp" (str "target/classes"
                            (System/getProperty "path.separator")

--- a/test-hello-world/deps.edn
+++ b/test-hello-world/deps.edn
@@ -3,5 +3,5 @@
         lib2/lib2 {:local/root "lib2/target/lib2.jar"}
         clj-easy/graal-build-time {:local/root "target/graal-build-time.jar"}}
  :aliases {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}
-                          babashka/fs {:mvn/version "0.1.0"}}
+                          babashka/fs {:mvn/version "0.4.19"}}
                    :ns-default build}}}


### PR DESCRIPTION
Adapts to current releases of Graal:
- `native-image` is now bundled with Graal
- `GRAALVM_HOME` env var is no longer described in Graal installation instructions. We still check it, but fallback to searching the `PATH`.