### PR TITLE
fix: compiled java jdk compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           bb: 'latest'
 
-      # any JDK will do to compile sources, but let's choose one
+      # any JDK > JDK8 will do to compile sources, but let's deliberately choose one
       - name: Setup Java
         uses: actions/setup-java@v3
         with:

--- a/build.clj
+++ b/build.clj
@@ -23,7 +23,12 @@
   (b/javac {:src-dirs bs/sources
             :class-dir class-dir
             :basis with-svm-basis
-            :javac-opts ["-source" "8" "-target" "8"]})
+            :javac-opts ["--release" "8" ;; technically jdk 17 is current graal min, but clojure
+                                         ;; produces jdk 8 compat classes, so we'll arbitrarily
+                                         ;; match that
+                                         ;; --release was introduce after jdk8, so we'll fail
+                                         ;; if compiling with <= jdk8, which is fine.
+                         "-Xlint"]})
   (println "Done compiling java sources."))
 
 (defn jar [_]


### PR DESCRIPTION
javac `-source` and `-target` opts were replaced with `--release` after jdk8. Use `--release`.

Also add `-Xlint` arg to javac to show warnings.