### PR TITLE
ci: test GraalVM variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,19 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - windows-latest
-
+          - 'ubuntu'
+          - 'windows'
+        distribution:
+          - 'graalvm'
+          - 'graalvm-community'
+        java-version:
+          - '17.0.8'
+          - '20.0.2'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -19,8 +24,8 @@ jobs:
       - name: Setup GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '17.0.8'
-          distribution: 'graalvm-community'
+          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.distribution }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Babashka

--- a/test-hello-world/bb.edn
+++ b/test-hello-world/bb.edn
@@ -100,6 +100,7 @@
              (shell -graalvm-native-image-exe
                     ;; note: we are omitting --initialize-at-build-time
                     "-jar" "target/hello-world.jar"
+                    "-O1" ;; basic optimization for faster build
                     "--no-fallback"
                     (str "-H:Path=" -native-image-path)
                     (str "-H:Name=" -native-image-uber-name)))
@@ -137,6 +138,7 @@
                 "-cp" (str "target/classes"
                            (System/getProperty "path.separator")
                            (-> (with-out-str (clojure "-Spath")) str/trim))
+                "-O1" ;; basic optimization for faster build
                 "--no-fallback"
                 (str "-H:Path=" -native-image-path)
                 (str "-H:Name=" -native-image-classes-name)


### PR DESCRIPTION
Expand matrix to also cover jdk 20 and GraalVM Oracle.

I don't see a need to add macOS at this time.
Linux and Windows should offer enough coverage.

Hopefully these will all run in parallel in not increase the build time.