### PR TITLE
test: Suppress pom "Skipping Coordinate" msgs

### DIFF
--- a/test-hello-world/build.clj
+++ b/test-hello-world/build.clj
@@ -1,6 +1,8 @@
 (ns build
   (:refer-clojure :exclude [compile])
-  (:require [clojure.tools.build.api :as b]))
+  (:require
+   [clojure.string :as str]
+   [clojure.tools.build.api :as b]))
 
 (def lib 'hello-world/hello-world)
 (def class-dir "target/classes")
@@ -8,13 +10,25 @@
 (def src-dirs ["src"])
 (def basis (b/create-basis))
 
+(defmacro with-err-str
+  [& body]
+  `(let [s# (new java.io.StringWriter)]
+     (binding [*err* s#]
+       ~@body
+       (str s#))))
+
 (defn uber [_]
   (println "Writing pom")
-  (b/write-pom {:class-dir class-dir
-                :lib lib
-                :version "1.0.0"
-                :basis basis
-                :src-dirs ["src"]})
+  (->> (b/write-pom {:class-dir class-dir
+                     :lib lib
+                     :version "1.0.0"
+                     :basis basis
+                     :src-dirs ["src"]})
+       with-err-str
+       str/split-lines
+       ;; Avoid confusing future me/you: suppress "Skipping coordinate" messages for our jars, we don't care, we are creating an uberjar
+       (remove #(re-matches #"^Skipping coordinate: \{:local/root .*target/(lib1|lib2|graal-build-time).jar.*" %))
+       (run! println))
   (b/copy-dir {:src-dirs src-dirs
                :target-dir class-dir})
   (println "Compile sources to classes")


### PR DESCRIPTION
During tests, when writing a pom file, "Skipping Coordinate" messages for our `:local/root` jar files are written to stderr.

We don't care that these coords are skipped for our pom. We are creating a test uberjar.

But each time I come back to this project, being forgetful, I see these warnings and wonder if I should care.

So, as a favour to future us, suppress them.