### PR TITLE
ci/dev: add clj-kondo linting

### DIFF
--- a/.clj-kondo/babashka/fs/config.edn
+++ b/.clj-kondo/babashka/fs/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {babashka.fs/with-temp-dir clojure.core/let}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,2 @@
+{:config-paths ^:replace [] ;; don't include user configs
+ }

--- a/.clj-kondo/http-kit/http-kit/config.edn
+++ b/.clj-kondo/http-kit/http-kit/config.edn
@@ -1,0 +1,3 @@
+
+{:hooks
+ {:analyze-call {org.httpkit.server/with-channel httpkit.with-channel/with-channel}}}

--- a/.clj-kondo/http-kit/http-kit/httpkit/with_channel.clj
+++ b/.clj-kondo/http-kit/http-kit/httpkit/with_channel.clj
@@ -1,0 +1,16 @@
+(ns httpkit.with-channel
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-channel [{node :node}]
+  (let [[request channel & body] (rest (:children node))]
+    (when-not (and request     channel) (throw (ex-info "No request or channel provided" {})))
+    (when-not (api/token-node? channel) (throw (ex-info "Missing channel argument" {})))
+    (let [new-node
+          (api/list-node
+            (list*
+              (api/token-node 'let)
+              (api/vector-node [channel (api/vector-node [])])
+              request
+              body))]
+
+      {:node new-node})))

--- a/.clj-kondo/lread/status-line/config.edn
+++ b/.clj-kondo/lread/status-line/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {lread.status-line/line clojure.tools.logging/infof
+           lread.status-line/die clojure.tools.logging/infof}}

--- a/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
+++ b/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
@@ -1,0 +1,5 @@
+{:lint-as
+ {rewrite-clj.zip/subedit-> clojure.core/->
+  rewrite-clj.zip/subedit->> clojure.core/->>
+  rewrite-clj.zip/edit-> clojure.core/->
+  rewrite-clj.zip/edit->> clojure.core/->>}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,36 @@ name: Test and Deploy
 on: [push, pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Babashka
+        uses: DeLaGuardo/setup-clojure@11.0
+        with:
+          bb: 'latest'
+
+      - name: Apply Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.deps.clj
+            ~/.gitlibs
+          key: lint-graal-build-time-${{ hashFiles('deps.edn','bb.edn') }}
+          restore-keys: "lint-graal-build-time-"
+
+      - name: Lint
+        run: bb lint
+
   test:
     runs-on: ${{ matrix.os }}-latest
     strategy:
@@ -43,9 +73,10 @@ jobs:
         with:
           path: |
             ~/.m2/repository
+            ~/.deps.clj
             ~/.gitlibs
           key: ${{ runner.os }}-graal-build-time-${{ hashFiles('**/deps.edn') }}
-          restore-keys: "$graal-build-time-"
+          restore-keys: ${{ runner.os }}-graal-build-time-
 
       - name: Run tests
         run: bb test
@@ -54,7 +85,7 @@ jobs:
         run: bb native-image-test
 
   deploy:
-    needs: test
+    needs: [lint, test]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
@@ -84,9 +115,10 @@ jobs:
         with:
           path: |
             ~/.m2/repository
+            ~/.deps.clj
             ~/.gitlibs
           key: ${{ runner.os }}-graal-build-time-${{ hashFiles('**/deps.edn') }}
-          restore-keys: "$graal-build-time-"
+          restore-keys: ${{ runner.os }}-graal-build-time-
 
       - name: Deploy to clojars
         env:

--- a/bb.edn
+++ b/bb.edn
@@ -1,5 +1,7 @@
 {:min-bb-version "1.3.182"
- :paths ["."]
+ :paths ["." "scripts"]
+ :deps {lread/status-line {:git/url "https://github.com/lread/status-line.git"
+                           :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}}
  :tasks
  {:requires ([babashka.fs :as fs]
              [babashka.tasks :as tasks]
@@ -51,6 +53,9 @@
   native-image-test {:doc "Runs native image hello world tests"
                      :task (shell {:dir "test-hello-world"}
                                   "bb native-image-test")}
+
+  lint {:doc "[--rebuild] Lint source code with clj-kondo"
+        :task lint/-main}
 
   change-log-check {:doc "Checks that change log is ready for publish"
                     :task (bs/change-log-check)}

--- a/deps.edn
+++ b/deps.edn
@@ -10,6 +10,8 @@
                  slipset/deps-deploy {:mvn/version "0.2.1"}}
           :ns-default build}
   :uber {:extra-paths ["test"]}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2023.07.13"}}
+              :main-opts ["-m" "clj-kondo.main"]}
   :test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}

--- a/scripts/lint.clj
+++ b/scripts/lint.clj
@@ -1,0 +1,64 @@
+(ns lint
+  (:require [babashka.classpath :as bbcp]
+            [babashka.cli :as cli]
+            [babashka.fs :as fs]
+            [babashka.tasks :as t]
+            [clojure.string :as string]
+            [lread.status-line :as status]))
+
+(def clj-kondo-cache ".clj-kondo/.cache")
+
+(defn- cache-exists? []
+  (fs/exists? clj-kondo-cache))
+
+(defn- delete-cache []
+  (when (cache-exists?)
+    (fs/delete-tree clj-kondo-cache)))
+
+(defn- build-cache []
+  (when (cache-exists?)
+    (delete-cache))
+  (let [clj-cp (-> (t/clojure {:out :string}
+                              "-Spath -M:test:build")
+                   with-out-str
+                   string/trim)
+        bb-cp (bbcp/get-classpath)]
+    (status/line :detail "- copying configs")
+    (t/clojure "-M:clj-kondo --skip-lint --copy-configs --lint" clj-cp bb-cp)
+    (status/line :detail "- creating cache")
+    (t/clojure "-M:clj-kondo --dependencies --lint" clj-cp bb-cp)))
+
+(defn- check-cache [{:keys [rebuild]}]
+  (status/line :head "clj-kondo: cache check")
+  (if-let [rebuild-reason (cond
+                            rebuild
+                            "Rebuild requested"
+
+                            (not (cache-exists?))
+                            "Cache not found"
+
+                            :else
+                            (let [updated-dep-files (fs/modified-since clj-kondo-cache ["deps.edn" "bb.edn"])]
+                              (when (seq updated-dep-files)
+                                (format "Found deps files newer than lint cache: %s" (mapv str updated-dep-files)))))]
+    (do (status/line :detail rebuild-reason)
+        (build-cache))
+    (status/line :detail "Using existing cache")))
+
+(defn- lint [opts]
+  (check-cache opts)
+  (status/line :head "clj-kondo: linting")
+  (let [{:keys [exit]}
+        (t/clojure {:continue true}
+                   "-M:clj-kondo --lint src test scripts build.clj build_shared.clj deps.edn bb.edn")]
+    (cond
+      (= 2 exit) (status/die exit "clj-kondo found one or more lint errors")
+      (= 3 exit) (status/die exit "clj-kondo found one or more lint warnings")
+      (> exit 0) (status/die exit "clj-kondo returned unexpected exit code"))))
+
+(defn -main [& args]
+  (when-let [opts (cli/parse-opts args)]
+    (lint opts)))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (apply -main *command-line-args*))


### PR DESCRIPTION
Clj-kondo saves my bacon so often, that I like to add it to CI pipelines.

new `bb lint` task:
- downloads deps kondo exported configs when needed
- runs kondo through jvm with specific version for repeatable lints

sneak in:
- tweaks to CI dep caching for other jobs