### PR TITLE
minor: build, test, release with current clojure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## Unreleased
 
 - Add license (and other common entries) to library pom file [#44](https://github.com/clj-easy/graal-build-time/issues/44)
+- Minor
+  - Build, test and release `graal-build-time` with current version of Clojure [#46](https://github.com/clj-easy/graal-build-time/issues/46)
 
 ## v1.0.5
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ This library automatically detects `.class` files created by Clojure and asks `n
 
 ## Usage
 
-We assume you are using a [current stable release of GraalVM](https://github.com/graalvm/graalvm-ce-builds/releases/).
-We don't support older releases.
+We assume you are using the current stable release of: 
+- [GraalVM Community Edition](https://github.com/graalvm/graalvm-ce-builds/releases/) or [GraalVM Oracle](https://www.graalvm.org/downloads/)
+- [Clojure](https://clojure.org/guides/install_clojure)
+
+We don't test against or support older releases.
 
 For your `native-image` build:
 1. If you are using `--initialize-at-build-time`, remove it.

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:deps {}
+{:deps {org.clojure/clojure {:mvn/version "1.11.3"}}
  :paths ["src" "resources"]
  :aliases
  {:svm

--- a/test-hello-world/bb.edn
+++ b/test-hello-world/bb.edn
@@ -98,6 +98,7 @@
                         "--features=clj_easy.graal_build_time.InitClojureClasses"
                         "-O1" ;; basic optimization for faster build
                         "--no-fallback"
+                        "--verbose"
                         "-o" exe))
              (println "Already built" full-exe)))}
 
@@ -135,6 +136,7 @@
                   "--features=clj_easy.graal_build_time.InitClojureClasses"
                   "-O1" ;; basic optimization for faster build
                   "--no-fallback"
+                  "--verbose"
                   "-o" exe
                   "hello_world.main")))
      (println "Already built" full-exe))}

--- a/test-hello-world/deps.edn
+++ b/test-hello-world/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src"]
- :deps {lib1/lib1 {:local/root "lib1/target/lib1.jar"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.3"}
+        lib1/lib1 {:local/root "lib1/target/lib1.jar"}
         lib2/lib2 {:local/root "lib2/target/lib2.jar"}
         clj-easy/graal-build-time {:local/root "target/graal-build-time.jar"}}
  :aliases {:build {:deps {clj-easy/build-helper {:local/root "../build-helper"}}

--- a/test-single-segment/deps.edn
+++ b/test-single-segment/deps.edn
@@ -1,4 +1,5 @@
-{:deps {org.clj-commons/digest {:mvn/version "1.4.100"}
+{:deps {org.clojure/clojure {:mvn/version "1.11.3"}
+        org.clj-commons/digest {:mvn/version "1.4.100"}
         clj-easy/graal-build-time {:local/root "target/graal-build-time.jar"}}
  :aliases {:build {:deps {clj-easy/build-helper {:local/root "../build-helper"}}
                    :ns-default build}}}


### PR DESCRIPTION
Also add `--verbose` to `native-image` invokations to make it easier to see what classpath is being used.

Closes #46