### PR TITLE
dev: bump clj-kondo

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,7 @@
                  slipset/deps-deploy {:mvn/version "0.2.2"}}
           :ns-default build}
   :uber {:extra-paths ["test"]}
-  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.24"}}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.08.01"}}
               :main-opts ["-m" "clj-kondo.main"]}
   :test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/scripts/lint.clj
+++ b/scripts/lint.clj
@@ -23,7 +23,7 @@
                    with-out-str
                    string/trim)
         bb-cp (bbcp/get-classpath)]
-    (status/line :detail "- copying libs and creating cache")
+    (status/line :detail "- copying lib configs and creating cache")
     (t/clojure "-M:clj-kondo --skip-lint --copy-configs --dependencies --parallel --lint" clj-cp bb-cp)))
 
 (defn- check-cache [{:keys [rebuild]}]

--- a/scripts/lint.clj
+++ b/scripts/lint.clj
@@ -23,10 +23,8 @@
                    with-out-str
                    string/trim)
         bb-cp (bbcp/get-classpath)]
-    (status/line :detail "- copying configs")
-    (t/clojure "-M:clj-kondo --skip-lint --copy-configs --lint" clj-cp bb-cp)
-    (status/line :detail "- creating cache")
-    (t/clojure "-M:clj-kondo --dependencies --lint" clj-cp bb-cp)))
+    (status/line :detail "- copying libs and creating cache")
+    (t/clojure "-M:clj-kondo --skip-lint --copy-configs --dependencies --parallel --lint" clj-cp bb-cp)))
 
 (defn- check-cache [{:keys [rebuild]}]
   (status/line :head "clj-kondo: cache check")
@@ -50,7 +48,7 @@
   (status/line :head "clj-kondo: linting")
   (let [{:keys [exit]}
         (t/clojure {:continue true}
-                   "-M:clj-kondo --lint src test scripts build.clj build_shared.clj deps.edn bb.edn")]
+                   "-M:clj-kondo --parallel --lint src test scripts build.clj build_shared.clj deps.edn bb.edn")]
     (cond
       (= 2 exit) (status/die exit "clj-kondo found one or more lint errors")
       (= 3 exit) (status/die exit "clj-kondo found one or more lint warnings")


### PR DESCRIPTION
Because who can resist, right?
Clj-kondo now supports copying configs and generating the cache for dependencies in one step, so move to that.