### PR TITLE
fix: munge package names for ns with special chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Unreleased
 
 - Add license (and other common entries) to library pom file [#44](https://github.com/clj-easy/graal-build-time/issues/44)
+- Munge package names so namespaces containing chars like `+` (e.g. `clojure+.walk`) are registered using their Java package name (e.g. `clojure_PLUS_`) where AOT-generated classes actually live
 - Minor
   - Build, test and release `graal-build-time` with current version of Clojure [#46](https://github.com/clj-easy/graal-build-time/issues/46)
 

--- a/src/clj_easy/graal_build_time/packages.clj
+++ b/src/clj_easy/graal_build_time/packages.clj
@@ -11,7 +11,8 @@
 (defn ^:private entry->package [nm split]
   (let [package (->> (str/split nm (re-pattern (str/re-quote-replacement split)))
                      drop-last
-                     (str/join "."))]
+                     (str/join ".")
+                     munge)]
     (when (str/blank? package)
       (println (str "[clj-easy/graal-build-time] WARN: Single segment namespace found for class: " nm ". "
                     "Because this class has no package, it cannot be registered for initialization at build time.")))

--- a/test-hello-world/src/gbt+test/core.clj
+++ b/test-hello-world/src/gbt+test/core.clj
@@ -1,0 +1,3 @@
+(ns gbt+test.core)
+
+(defn dummy [] :dummy)

--- a/test-hello-world/src/hello_world/main.clj
+++ b/test-hello-world/src/hello_world/main.clj
@@ -1,7 +1,8 @@
 (ns hello-world.main
   (:require [hello.core]
             [gbt-test-org.core]
-            [gbt-test-org.p2.core])
+            [gbt-test-org.p2.core]
+            [gbt+test.core])
   (:gen-class))
 
 (defn -main []
@@ -9,4 +10,5 @@
   (hello.core/dummy)
   (gbt-test-org.core/dummy)
   (gbt-test-org.p2.core/dummy)
+  (gbt+test.core/dummy)
   (println "Hello world"))

--- a/test/clj_easy/graal_build_time/packages_test.clj
+++ b/test/clj_easy/graal_build_time/packages_test.clj
@@ -7,7 +7,7 @@
 (deftest hello-world-package-list-test
   (-> (p/process ["bb" "build-hello-world"] {:inherit true})
       (p/check))
-  (let [expected-packages "clojure, clj_easy.graal_build_time, gbt_test_org, hello, hello_world"]
+  (let [expected-packages "clojure, clj_easy.graal_build_time, gbt_PLUS_test, gbt_test_org, hello, hello_world"]
     (testing "packages from directory"
       (is (= expected-packages
              (-> (packages/-list (->> ["test-hello-world/target/classes"


### PR DESCRIPTION
Clojure AOT writes `__init.class` at un-munged path (e.g. `clojure+/walk__init.class`) but generated fn classes live in munged Java package (clojure_PLUS_). Extracted package name now passes through `clojure.core/munge` so GraalVM directive matches where real classes live.